### PR TITLE
update BNL metadata in cvmfs_info

### DIFF
--- a/cvmfs_info.data
+++ b/cvmfs_info.data
@@ -16,7 +16,7 @@
   'cvmfs-s1bnl.opensciencegrid.org' => {
     'name' => 'BNL',
   },
-  'cvmfs.racf.bnl.gov' => {
+  'cvmfs.sdcc.bnl.gov' => {
     'name' => 'BNL',
   },
   'cvmfs-wlcg.gridpp.rl.ac.uk' => {


### PR DESCRIPTION
changing "legacy" 'racf' string in BNL URL to 'sdcc'.